### PR TITLE
Fix issue when mediaElSrc.mediaElement is undefined

### DIFF
--- a/js/visualizer.js
+++ b/js/visualizer.js
@@ -122,7 +122,8 @@ export default () => {
             },
 
             reqFrame(func) {
-                if(this.mediaElSrc.mediaElement.paused || this.canvas.offsetHeight === 0) {
+                if(( this.mediaElSrc.mediaElement && this.mediaElSrc.mediaElement.paused)
+                     || this.canvas.offsetHeight === 0) {
                     //wait a while and try again
                     setTimeout(() => {
                         this.reqFrame(func);


### PR DESCRIPTION
#32 

I don't know why, but on Firefox, `mediaElSrc.mediaElement` is undefined when you pass in `reqFrame` method.

Adding the test of `mediaElSrc.mediaElement` check if it is defined or not.